### PR TITLE
Modified regex for demo done command

### DIFF
--- a/scripts/github-jira.coffee
+++ b/scripts/github-jira.coffee
@@ -58,13 +58,17 @@ module.exports = (robot) ->
     res.end "OK"
 
   # Command: hubot demo is done for <story>
-  robot.respond /demo\s+is\s+done\s+for\s+([A-Z0-9\-]+)/i, (msg) ->
-    ticket = msg.match[1]
+  robot.respond /demo\s+([A-Z\' ']+)\s+([A-Z0-9\-]+)/i, (msg) ->
+    done = msg.match[1].match('done|complete|over')
+    ticket = msg.match[2]
     user = msg.message.user.name
     robot.logger.info ticket + ",Demo" + "," + user
-    setSubtaskDone ticket, "Demo", user
-    msg.send "OK, marking Demo as done."
-
+    
+    if done
+      setSubtaskDone ticket, "Demo", user
+      msg.send "OK, marking Demo for " + ticket + " as done."
+    else
+      msg.send "Something went wrong!!!"
 # Get HTTP Basic Auth string
 getAuth = () ->
   username = process.env.HUBOT_JIRA_USERNAME


### PR DESCRIPTION
Currently synbot responds to only one sentence format for "demo done" command:

```
@synbot: demo is done for SAPP-1234
```

This pull request allows flexibility in the command to be one of the following:

```
@synbot: demo has been done for SAPP-1234
@synbot: demo is completed for SAPP-1234
@synbot: demo is over for SAPP-1234
```
