### PR TITLE
Added query in error message.

### DIFF
--- a/scripts/synduit.coffee
+++ b/scripts/synduit.coffee
@@ -34,7 +34,7 @@ module.exports = (robot) ->
     query = msg.match[1]
     cancelUser msg, query, (err, res) ->
       if err
-        msg.send "Error canceling " + query
+        msg.send "Error canceling *" + query + "*"
         console.log "Error canceling " + query + " from Synduit: " + res.statusCode
       else
         if res.statusCode == 204

--- a/scripts/synduit.coffee
+++ b/scripts/synduit.coffee
@@ -34,13 +34,13 @@ module.exports = (robot) ->
     query = msg.match[1]
     cancelUser msg, query, (err, res) ->
       if err
-        msg.send "Error canceling user"
-        console.log "Error canceling user from Synduit: " + res.statusCode
+        msg.send "Error canceling " + query
+        console.log "Error canceling " + query + " from Synduit: " + res.statusCode
       else
         if res.statusCode == 204
           msg.send query + " is canceling"
         else
-          msg.send "Error canceling user from Synduit: " + res.statusCode
+          msg.send "Error canceling *" + query + "* from Synduit: " + res.statusCode
 
   # Command: hubot referral <query>
   robot.respond /refer[r]*al\s+([\w\W]+)/i, (msg) ->


### PR DESCRIPTION
https://brandentity.atlassian.net/browse/SCOM-4492
when synbot says `error cancelling user`. it should include username in it. otherwise its hard to match which error to which command we issued.

example: `Error cancelling user "bob@rocketmail.com" from Synduit: 404`

This will do.
Error cancelling user **bob@rocketmail.com** from Synduit: 404